### PR TITLE
Add exception handling to serial decode

### DIFF
--- a/PythonDaemon/daemon.py
+++ b/PythonDaemon/daemon.py
@@ -21,8 +21,9 @@ def run():
     Do setup and start threads
     """
     db_queue = queue.Queue()
+    serial_output_queue = queue.Queue()
 
-    ser_handler = SerialHandler(db_queue)
+    ser_handler = SerialHandler(db_queue, serial_output_queue)
     db_handler = DbClient(db_queue)
     websocket_handler = WebsocketHandler()
 

--- a/PythonDaemon/dummyPrint/dummyPrint.ino
+++ b/PythonDaemon/dummyPrint/dummyPrint.ino
@@ -8,12 +8,17 @@
   http://www.arduino.cc/en/Tutorial/DigitalReadSerial
 */
 
-// digital pin 2 has a pushbutton attached to it. Give it a name:
-int pushButton = 2;
+// LED on pin 13
 
+int led = 13;
+
+int rcv;
+
+int flag = 0;
 // the setup routine runs once when you press reset:
 void setup() {
   // initialize serial communication at 9600 bits per second:
+  pinMode(led, OUTPUT);
   Serial.begin(115200);
 }
 
@@ -23,6 +28,22 @@ void loop() {
   Serial.println("Vol=2"); 
   Serial.println("Trig=3");
   Serial.println("Pres=4");
+
+  if (Serial.available() > 0) {
+    rcv = Serial.read();
+    if(rcv == 'T'){
+      flag=1;
+    }
+
+    rcv = Serial.read(); // handle newline
+  }
+
+  if (flag == 1){
+    Serial.println("OK");
+  } else {
+    Serial.println("NOK");
+  }
  
-  delay(40);
+ 
+  delay(1000);
 }

--- a/PythonDaemon/dummyPrint/dummyPrint.ino
+++ b/PythonDaemon/dummyPrint/dummyPrint.ino
@@ -24,5 +24,5 @@ void loop() {
   Serial.println("Trig=3");
   Serial.println("Pres=4");
  
-  delay(10);
+  delay(40);
 }

--- a/PythonDaemon/ventilator_database.py
+++ b/PythonDaemon/ventilator_database.py
@@ -29,7 +29,7 @@ class DbClient():
         self.__store_value(collection, trigger_val)
 
     def __store_value(self, collection, val):
-        collection.insert_one({'value': val, 'loggedAt': datetime.now()})
+        collection.insert_one({'value': val, 'loggedAt': datetime.utcnow()})
 
     def run(self, name):
         print("Starting {}".format(name))

--- a/PythonDaemon/ventilator_serial.py
+++ b/PythonDaemon/ventilator_serial.py
@@ -9,12 +9,27 @@ class SerialHandler():
     def __init__(self, db_queue, port='/dev/ttyACM0', baudrate=115200):
         self.ser = serial.Serial(port, baudrate)
         self.queue = db_queue
+        self.errorcounter = 0
 
     def run(self, name):
         print("Starting {}".format(name))
         while True:
             line = self.ser.readline()
-            line = line.decode('utf-8')
+            try:
+                line = line.decode('utf-8')
+            except UnicodeDecodeError:
+                print("Failure decoding serial message, continuing")
+                if self.errorcounter == 0:
+                    self.errorcounter += 1
+                    print("utf-8 decode errorcounter: {}".format(self.errorcounter))
+                    continue
+                else:
+                    print("Repeatedly unable to decode serial messages, aborting!")
+                    raise SystemExit(-1)
+                # TODO: At the start it can happen that we get an incorrect message
+                # due to incomplete data. I do a hard abort here to ensure that this only
+                # happens once. We need to determine what a tolerable level of failure is here.
+
             tokens = line.split('=', 1)
             val = tokens[-1].rstrip('\r\n')
             if line.startswith(('bpm=')):

--- a/PythonDaemon/ventilator_serial.py
+++ b/PythonDaemon/ventilator_serial.py
@@ -8,6 +8,8 @@ class SerialHandler():
 
     def __init__(self, db_queue, port='/dev/ttyACM0', baudrate=115200):
         self.ser = serial.Serial(port, baudrate)
+        self.ser.reset_input_buffer()
+        self.ser.reset_output_buffer()
         self.queue = db_queue
         self.errorcounter = 0
 

--- a/PythonDaemon/ventilator_serial.py
+++ b/PythonDaemon/ventilator_serial.py
@@ -2,20 +2,32 @@
 Ventilator Serial Handler
 """
 import serial
+import queue
 
 
 class SerialHandler():
 
-    def __init__(self, db_queue, port='/dev/ttyACM0', baudrate=115200):
+    def __init__(self,db_queue, out_queue, port='/dev/ttyACM0', baudrate=115200):
         self.ser = serial.Serial(port, baudrate)
         self.ser.reset_input_buffer()
         self.ser.reset_output_buffer()
-        self.queue = db_queue
+        self.db_queue = db_queue # Enqueue to
+        self.out_queue = out_queue
         self.errorcounter = 0
 
     def run(self, name):
         print("Starting {}".format(name))
         while True:
+            try:
+                msg = self.out_queue.get(block=False)
+            except queue.Empty:
+                msg = None
+
+            if msg != None:
+                print(bytes(msg['val'], 'utf-8'))
+                self.ser.write(msg['val'].encode())
+
+
             line = self.ser.readline()
             try:
                 line = line.decode('utf-8')
@@ -32,13 +44,14 @@ class SerialHandler():
                 # due to incomplete data. I do a hard abort here to ensure that this only
                 # happens once. We need to determine what a tolerable level of failure is here.
 
+
             tokens = line.split('=', 1)
             val = tokens[-1].rstrip('\r\n')
             if line.startswith(('bpm=')):
-                self.queue.put({'type': 'BPM', 'val': val})
+                self.db_queue.put({'type': 'BPM', 'val': val})
             elif line.startswith(('Vol=')):
-                self.queue.put({'type': 'VOL', 'val': val})
+                self.db_queue.put({'type': 'VOL', 'val': val})
             elif line.startswith(('Trig=')):
-                self.queue.put({'type': 'TRIG', 'val': val})
+                self.db_queue.put({'type': 'TRIG', 'val': val})
             elif line.startswith(('Pres=')):
-                self.queue.put({'type': 'PRES', 'val': val})
+                self.db_queue.put({'type': 'PRES', 'val': val})

--- a/PythonDaemon/ventilator_websocket.py
+++ b/PythonDaemon/ventilator_websocket.py
@@ -46,7 +46,8 @@ class WebsocketHandler():
 
     def __init__(self, addr='localhost', port=3001):
         url = "ws://" + addr + ":" + str(port) + "/"
-        self.ws = websocket.create_connection(url)
+        self.ws = websocket.WebSocket()
+        self.ws.connect(url)
         self.id = 1
 
 


### PR DESCRIPTION
At startup it's possible that we receive incomplete serial data. We need to
account for this. We'll need to determine what level of errors are tolerable
here. For testing purposes now I would stop the application so we get immediate
feedback if this occurs more than once.

Signed-off-by: Frank Vanbever <frank.vanbever@essensium.com>